### PR TITLE
[feat] Expand the database schema / GraphQL API to support more common queries

### DIFF
--- a/us-congress/db/schema.sql
+++ b/us-congress/db/schema.sql
@@ -208,6 +208,45 @@ CREATE INDEX idx_positions_vote_party ON vote_positions (vote_id, party);
 CREATE INDEX idx_positions_bioguide_vote ON vote_positions (bioguide_id, vote_id);
 
 -- ---------------------------------------------------------------------------
+-- AGGREGATION VIEWS
+-- Curated server-side rollups over vote_positions. PostGraphile exposes each as
+-- a filterable connection (allVotePartyBreakdowns, etc.). They are deliberately
+-- narrow: callers filter by vote_id / bioguide_id (hitting existing indexes)
+-- rather than authoring arbitrary GROUP BYs over the whole table. Plain (not
+-- materialized) views — always current, computed on the (small, filtered) slice.
+-- ---------------------------------------------------------------------------
+
+-- Per-vote party × position counts, e.g. "how did each party split on this vote?"
+-- Filter by vote_id; served by idx_positions_vote_party (vote_id, party).
+CREATE VIEW vote_party_breakdown AS
+  SELECT vote_id, party, position, count(*)::int AS positions
+  FROM vote_positions
+  GROUP BY vote_id, party, position;
+
+COMMENT ON VIEW vote_party_breakdown IS E'Per-vote breakdown of how each party voted: one row per (vote, party, position) with a count. Filter by voteId.';
+
+-- Per-vote position totals (Yea/Nay/Present/Not Voting tallies for a vote).
+-- Filter by vote_id; served by idx_positions_vote_id.
+CREATE VIEW vote_totals AS
+  SELECT vote_id, position, count(*)::int AS positions
+  FROM vote_positions
+  GROUP BY vote_id, position;
+
+COMMENT ON VIEW vote_totals IS E'Per-vote position totals: one row per (vote, position) with a count across all members. Filter by voteId.';
+
+-- A legislator's voting record summarised by congress × vote category × position.
+-- Filter by bioguide_id (served by idx_positions_bioguide); joins votes for the
+-- congress/category dimensions, which live on the votes table.
+CREATE VIEW member_voting_summary AS
+  SELECT vp.bioguide_id, v.congress, v.category, vp.position,
+         count(*)::int AS positions
+  FROM vote_positions vp
+  JOIN votes v ON v.vote_id = vp.vote_id
+  GROUP BY vp.bioguide_id, v.congress, v.category, vp.position;
+
+COMMENT ON VIEW member_voting_summary IS E'A member''s voting record summarised by congress, vote category, and position, with counts. Filter by bioguideId (optionally congress/category).';
+
+-- ---------------------------------------------------------------------------
 -- BILL COSPONSORS
 -- ---------------------------------------------------------------------------
 CREATE TABLE bill_cosponsors (

--- a/us-congress/db/schema.sql
+++ b/us-congress/db/schema.sql
@@ -247,6 +247,38 @@ CREATE VIEW member_voting_summary AS
 COMMENT ON VIEW member_voting_summary IS E'A member''s voting record summarised by congress, vote category, and position, with counts. Filter by bioguideId (optionally congress/category).';
 
 -- ---------------------------------------------------------------------------
+-- VOTING SIMILARITY (current congress only) — MATERIALIZED
+-- Pairwise agreement between members: for every pair, how many votes they both
+-- cast a Yea/Nay on (shared_votes) and how many they voted the same way (agreed).
+-- This is an O(n²)-within-each-vote self-join — too expensive to compute per
+-- request — so it is materialized and refreshed after vote ingestion (see the
+-- REFRESH hook in ingester/src/ingest-votes.js run()). Scoped to the current
+-- congress to keep the refresh tractable; historical congresses are computed
+-- client-side by the docs site's similarity demo.
+--
+-- The agreement ratio (agreed / shared_votes) and any minimum-shared-votes
+-- threshold are applied by the consumer; this view stays a raw count table.
+-- ---------------------------------------------------------------------------
+CREATE MATERIALIZED VIEW vote_similarity_current AS
+  SELECT a.bioguide_id AS member_a, b.bioguide_id AS member_b,
+         v.chamber,
+         count(*)::int                                        AS shared_votes,
+         count(*) FILTER (WHERE a.position = b.position)::int AS agreed
+  FROM vote_positions a
+  JOIN vote_positions b
+    ON b.vote_id = a.vote_id AND a.bioguide_id < b.bioguide_id
+  JOIN votes v ON v.vote_id = a.vote_id
+  WHERE a.position IN ('Yea', 'Nay') AND b.position IN ('Yea', 'Nay')
+    AND v.congress = (SELECT max(congress) FROM votes)
+  GROUP BY a.bioguide_id, b.bioguide_id, v.chamber;
+
+-- Unique index is required for REFRESH MATERIALIZED VIEW CONCURRENTLY.
+CREATE UNIQUE INDEX idx_vote_similarity_current_pair
+  ON vote_similarity_current (member_a, member_b, chamber);
+
+COMMENT ON MATERIALIZED VIEW vote_similarity_current IS E'Pairwise voting agreement for the current congress: one row per (member_a, member_b, chamber) with shared_votes (both cast Yea/Nay) and agreed (voted the same). Refreshed after vote ingestion. Compute agreement as agreed::float / shared_votes.';
+
+-- ---------------------------------------------------------------------------
 -- BILL COSPONSORS
 -- ---------------------------------------------------------------------------
 CREATE TABLE bill_cosponsors (

--- a/us-congress/db/schema.sql
+++ b/us-congress/db/schema.sql
@@ -247,36 +247,45 @@ CREATE VIEW member_voting_summary AS
 COMMENT ON VIEW member_voting_summary IS E'A member''s voting record summarised by congress, vote category, and position, with counts. Filter by bioguideId (optionally congress/category).';
 
 -- ---------------------------------------------------------------------------
--- VOTING SIMILARITY (current congress only) — MATERIALIZED
--- Pairwise agreement between members: for every pair, how many votes they both
--- cast a Yea/Nay on (shared_votes) and how many they voted the same way (agreed).
--- This is an O(n²)-within-each-vote self-join — too expensive to compute per
--- request — so it is materialized and refreshed after vote ingestion (see the
--- REFRESH hook in ingester/src/ingest-votes.js run()). Scoped to the current
--- congress to keep the refresh tractable; historical congresses are computed
--- client-side by the docs site's similarity demo.
+-- VOTING SIMILARITY (all congresses) — incrementally maintained table
+-- Pairwise agreement between members within a congress: for every pair, how many
+-- votes they both cast a Yea/Nay on (shared_votes) and how many they voted the
+-- same way (agreed). This is an O(n²)-within-each-vote self-join — too expensive
+-- to compute per request — so it is precomputed here.
+--
+-- Each congress's similarity is self-contained, and historical vote data is
+-- immutable, so only the current congress ever changes. The ingester rebuilds
+-- one congress's partition at a time (DELETE+INSERT in a transaction) for the
+-- congresses that received new votes — see ingest-votes.js run(). The first full
+-- ingest backfills every congress; steady-state runs only touch the current one.
 --
 -- The agreement ratio (agreed / shared_votes) and any minimum-shared-votes
--- threshold are applied by the consumer; this view stays a raw count table.
+-- threshold are applied by the consumer; this table stays a raw count table.
 -- ---------------------------------------------------------------------------
-CREATE MATERIALIZED VIEW vote_similarity_current AS
-  SELECT a.bioguide_id AS member_a, b.bioguide_id AS member_b,
-         v.chamber,
-         count(*)::int                                        AS shared_votes,
-         count(*) FILTER (WHERE a.position = b.position)::int AS agreed
-  FROM vote_positions a
-  JOIN vote_positions b
-    ON b.vote_id = a.vote_id AND a.bioguide_id < b.bioguide_id
-  JOIN votes v ON v.vote_id = a.vote_id
-  WHERE a.position IN ('Yea', 'Nay') AND b.position IN ('Yea', 'Nay')
-    AND v.congress = (SELECT max(congress) FROM votes)
-  GROUP BY a.bioguide_id, b.bioguide_id, v.chamber;
+CREATE TABLE vote_similarity (
+  congress     SMALLINT NOT NULL,
+  chamber      CHAR(1)  NOT NULL,
+  member_a     TEXT     NOT NULL,        -- pair stored once, member_a < member_b
+  member_b     TEXT     NOT NULL,
+  shared_votes INT      NOT NULL,        -- votes where both cast Yea/Nay
+  agreed       INT      NOT NULL,        -- of those, votes where they matched
 
--- Unique index is required for REFRESH MATERIALIZED VIEW CONCURRENTLY.
-CREATE UNIQUE INDEX idx_vote_similarity_current_pair
-  ON vote_similarity_current (member_a, member_b, chamber);
+  PRIMARY KEY (congress, chamber, member_a, member_b)
+);
 
-COMMENT ON MATERIALIZED VIEW vote_similarity_current IS E'Pairwise voting agreement for the current congress: one row per (member_a, member_b, chamber) with shared_votes (both cast Yea/Nay) and agreed (voted the same). Refreshed after vote ingestion. Compute agreement as agreed::float / shared_votes.';
+COMMENT ON TABLE vote_similarity IS E'Pairwise voting agreement, per congress: one row per (congress, chamber, member_a, member_b) with shared_votes (both cast Yea/Nay) and agreed (voted the same). Pairs are stored once with member_a < member_b. Maintained by the vote ingester. Compute agreement as agreed::float / shared_votes.';
+
+-- Rebuild bookkeeping: the high-water mark of votes.updated_at that each
+-- congress's vote_similarity rows were last built from. The ingester rebuilds a
+-- congress whenever its max(votes.updated_at) exceeds built_through (or no row
+-- exists yet), and advances built_through only after a successful rebuild — so a
+-- failed or interrupted rebuild leaves the congress stale and is retried next run.
+CREATE TABLE vote_similarity_state (
+  congress      SMALLINT    PRIMARY KEY,
+  built_through TIMESTAMPTZ NOT NULL
+);
+
+COMMENT ON TABLE vote_similarity_state IS E'@omit\nRebuild bookkeeping for vote_similarity — internal, not exposed via GraphQL.';
 
 -- ---------------------------------------------------------------------------
 -- BILL COSPONSORS

--- a/us-congress/docs/docs/schema/index.md
+++ b/us-congress/docs/docs/schema/index.md
@@ -175,6 +175,27 @@ positions: 45 }`.
 `congress` and `category` are optional — omit them for a member's full record
 across all congresses and categories.
 
+**Voting similarity** — for the **current congress**, pairwise agreement between
+members is precomputed in `allVoteSimilarityCurrents`. Each row gives `sharedVotes`
+(votes where both members cast a Yea/Nay) and `agreed` (votes where they matched);
+compute the agreement ratio as `agreed / sharedVotes`. Find a member's closest
+allies:
+
+```graphql
+{
+  allVoteSimilarityCurrents(
+    filter: { chamber: { equalTo: "s" }, memberA: { equalTo: "W000817" } }
+    orderBy: AGREED_DESC
+    first: 5
+  ) {
+    nodes { memberB sharedVotes agreed }
+  }
+}
+```
+
+Pairs are stored once with `memberA < memberB`, so to find all of one member's
+pairings you may need to match on `memberA` **or** `memberB`.
+
 ---
 
 :::note

--- a/us-congress/docs/docs/schema/index.md
+++ b/us-congress/docs/docs/schema/index.md
@@ -126,6 +126,55 @@ Reverse relationships (one-to-many) return a connection with `nodes`:
 }
 ```
 
+### Aggregation
+
+Some common counts are exposed as **aggregation views** — the database does the
+grouping, so you don't have to fetch every position row and tally it client-side.
+Each is a filterable connection like any other type. Filter them to the slice you
+care about (a vote, a member) rather than scanning everything.
+
+**Party breakdown of a vote** — how each party split, in one round-trip:
+
+```graphql
+{
+  allVotePartyBreakdowns(filter: { voteId: { equalTo: "s83-119.2025" } }) {
+    nodes { party position positions }
+  }
+}
+```
+
+Returns one row per (party, position), e.g. `{ party: "D", position: "Yea",
+positions: 45 }`.
+
+**Position totals for a vote** — the overall Yea/Nay/Present/Not Voting tally:
+
+```graphql
+{
+  allVoteTotals(filter: { voteId: { equalTo: "s83-119.2025" } }) {
+    nodes { position positions }
+  }
+}
+```
+
+**A member's voting record**, summarised by congress and vote category:
+
+```graphql
+{
+  allMemberVotingSummaries(
+    filter: {
+      bioguideId: { equalTo: "W000817" }
+      congress: { equalTo: 119 }
+      category: { equalTo: "cloture" }
+    }
+  ) {
+    nodes { position positions }
+  }
+}
+```
+
+`congress` and `category` are optional — omit them for a member's full record
+across all congresses and categories.
+
 ---
 
 :::note

--- a/us-congress/docs/docs/schema/index.md
+++ b/us-congress/docs/docs/schema/index.md
@@ -175,16 +175,20 @@ positions: 45 }`.
 `congress` and `category` are optional — omit them for a member's full record
 across all congresses and categories.
 
-**Voting similarity** — for the **current congress**, pairwise agreement between
-members is precomputed in `allVoteSimilarityCurrents`. Each row gives `sharedVotes`
+**Voting similarity** — pairwise agreement between members within a congress is
+precomputed in `allVoteSimilarities` (all congresses). Each row gives `sharedVotes`
 (votes where both members cast a Yea/Nay) and `agreed` (votes where they matched);
-compute the agreement ratio as `agreed / sharedVotes`. Find a member's closest
-allies:
+compute the agreement ratio as `agreed / sharedVotes`. Filter by `congress` (and
+usually `chamber`). Find a member's closest allies in a given congress:
 
 ```graphql
 {
-  allVoteSimilarityCurrents(
-    filter: { chamber: { equalTo: "s" }, memberA: { equalTo: "W000817" } }
+  allVoteSimilarities(
+    filter: {
+      congress: { equalTo: 119 }
+      chamber: { equalTo: "s" }
+      memberA: { equalTo: "W000817" }
+    }
     orderBy: AGREED_DESC
     first: 5
   ) {

--- a/us-congress/ingester/src/ingest-votes.js
+++ b/us-congress/ingester/src/ingest-votes.js
@@ -308,6 +308,27 @@ async function run() {
       `skipped (up to date): ${totalSkipped}, failed: ${totalFailed}`,
     );
 
+    // Refresh the current-congress voting-similarity matrix only when new votes
+    // actually landed (most hourly runs ingest nothing). CONCURRENTLY keeps the
+    // view readable during the refresh. The run is already committed and marked
+    // 'success' above, so a refresh failure is logged but not fatal — the matrix
+    // simply stays at its previous contents until the next successful refresh.
+    if (totalIngested > 0) {
+      try {
+        const t0 = Date.now();
+        await client.query(
+          'REFRESH MATERIALIZED VIEW CONCURRENTLY vote_similarity_current',
+        );
+        logger.info(
+          `Refreshed vote_similarity_current in ${Date.now() - t0} ms`,
+        );
+      } catch (err) {
+        logger.error(
+          `vote_similarity_current refresh failed (data is ingested; matrix is stale): ${err.message}`,
+        );
+      }
+    }
+
     if (process.env.HEALTHCHECK_VOTES_INGEST_URL) {
       await fetch(process.env.HEALTHCHECK_VOTES_INGEST_URL).catch(() => {});
     }

--- a/us-congress/ingester/src/ingest-votes.js
+++ b/us-congress/ingester/src/ingest-votes.js
@@ -271,6 +271,79 @@ async function processVoteFile(client, filePath) {
 }
 
 // ---------------------------------------------------------------------------
+// Congresses whose vote_similarity rows are stale: their max(votes.updated_at)
+// is newer than the watermark from their last successful rebuild (or they have
+// never been built). votes.updated_at is a reliable signal — upsertVote runs in
+// the same transaction as replacePositions and the trg_votes_updated_at trigger
+// bumps it on every change, so any position change moves the parent vote's
+// updated_at. Cheap: votes is small and congress is indexed.
+//
+// Returns [{ congress, curMax }]. curMax is captured here, BEFORE the rebuild,
+// and written as the new watermark only on success — so a vote updated during
+// the rebuild leaves the congress stale (retried next run) rather than being
+// silently marked built.
+// ---------------------------------------------------------------------------
+async function staleCongresses(client) {
+  const { rows } = await client.query(
+    `SELECT v.congress AS congress, max(v.updated_at) AS cur_max
+     FROM votes v
+     LEFT JOIN vote_similarity_state s ON s.congress = v.congress
+     GROUP BY v.congress, s.built_through
+     HAVING s.built_through IS NULL OR max(v.updated_at) > s.built_through
+     ORDER BY v.congress`,
+  );
+  return rows.map((r) => ({ congress: r.congress, curMax: r.cur_max }));
+}
+
+// ---------------------------------------------------------------------------
+// Rebuild the voting-similarity rows for a single congress, and advance its
+// watermark — all in one transaction.
+//
+// DELETE + INSERT (+ watermark UPSERT) inside one transaction so concurrent
+// readers see the old partition until the new one is committed atomically
+// (never an empty slice), and so the watermark can only advance if the rebuild
+// committed. Scoped to one congress via a CTE prefilter so cost is independent
+// of how much historical data exists. Excludes Present / Not Voting / VP (only
+// Yea/Nay count toward agreement). `builtThrough` is the max(votes.updated_at)
+// captured before the rebuild (see staleCongresses).
+// ---------------------------------------------------------------------------
+async function rebuildSimilarityForCongress(client, congress, builtThrough) {
+  await client.query('BEGIN');
+  try {
+    await client.query('DELETE FROM vote_similarity WHERE congress = $1', [
+      congress,
+    ]);
+    await client.query(
+      `INSERT INTO vote_similarity
+         (congress, chamber, member_a, member_b, shared_votes, agreed)
+       WITH cpos AS (
+         SELECT vp.vote_id, vp.bioguide_id, vp.position, v.congress, v.chamber
+         FROM vote_positions vp
+         JOIN votes v ON v.vote_id = vp.vote_id
+         WHERE v.congress = $1 AND vp.position IN ('Yea', 'Nay')
+       )
+       SELECT a.congress, a.chamber, a.bioguide_id, b.bioguide_id,
+              count(*)::int,
+              count(*) FILTER (WHERE a.position = b.position)::int
+       FROM cpos a
+       JOIN cpos b ON b.vote_id = a.vote_id AND a.bioguide_id < b.bioguide_id
+       GROUP BY a.congress, a.chamber, a.bioguide_id, b.bioguide_id`,
+      [congress],
+    );
+    await client.query(
+      `INSERT INTO vote_similarity_state (congress, built_through)
+       VALUES ($1, $2)
+       ON CONFLICT (congress) DO UPDATE SET built_through = EXCLUDED.built_through`,
+      [congress, builtThrough],
+    );
+    await client.query('COMMIT');
+  } catch (err) {
+    await client.query('ROLLBACK');
+    throw err;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 async function run() {
@@ -308,23 +381,27 @@ async function run() {
       `skipped (up to date): ${totalSkipped}, failed: ${totalFailed}`,
     );
 
-    // Refresh the current-congress voting-similarity matrix only when new votes
-    // actually landed (most hourly runs ingest nothing). CONCURRENTLY keeps the
-    // view readable during the refresh. The run is already committed and marked
-    // 'success' above, so a refresh failure is logged but not fatal — the matrix
-    // simply stays at its previous contents until the next successful refresh.
-    if (totalIngested > 0) {
+    // Rebuild vote_similarity for every congress whose vote data has changed
+    // since its last successful rebuild (see staleCongresses). This is driven by
+    // actual staleness, not by what was ingested this run, so a rebuild that
+    // failed or was interrupted on a previous run is retried automatically — its
+    // watermark was never advanced. On a fresh DB every congress is stale (full
+    // backfill); steady state, only the current congress is stale. Each rebuild
+    // is its own transaction: failures are logged but non-fatal (the ingestion
+    // is already committed and the run marked 'success'), and the congress simply
+    // remains stale for the next run.
+    const stale = await staleCongresses(client);
+    for (const { congress, curMax } of stale) {
       try {
         const t0 = Date.now();
-        await client.query(
-          'REFRESH MATERIALIZED VIEW CONCURRENTLY vote_similarity_current',
-        );
+        await rebuildSimilarityForCongress(client, congress, curMax);
         logger.info(
-          `Refreshed vote_similarity_current in ${Date.now() - t0} ms`,
+          `Rebuilt vote_similarity for congress ${congress} in ${Date.now() - t0} ms`,
         );
       } catch (err) {
         logger.error(
-          `vote_similarity_current refresh failed (data is ingested; matrix is stale): ${err.message}`,
+          `vote_similarity rebuild for congress ${congress} failed ` +
+          `(votes are ingested; similarity is stale, will retry next run): ${err.message}`,
         );
       }
     }


### PR DESCRIPTION
# Expand the database schema / GraphQL API to support more common queries

Closes #38 and #37 

## What this does

1. Adds server-side aggregation to the GovQL GraphQL API as a small set of SQL views
2. Adds a precomputed similarity table

End goal was to allow common analytical questions to be answered in one
round-trip instead of fetching every `vote_positions` row and tallying client-side.
PostGraphile auto-exposes each as a filterable connection — no server, resolver, or
dependency changes.

New queryable objects:

| Connection | Answers |
|---|---|
| `allVotePartyBreakdowns` | How did each party split on a vote? (vote × party × position counts) |
| `allVoteTotals` | Overall Yea/Nay/Present/Not Voting tally for a vote |
| `allMemberVotingSummaries` | A member's record by congress × vote category × position |
| `allVoteSimilarities` | Pairwise voting agreement between members, per congress |

## Why views

Curated views let clients run only specific, pre-shaped aggregations, each filtered to a
small indexed slice (a vote, a member, a congress). That keeps the API's query surface
bounded — no unbounded client-authored `GROUP BY`s over the multi-million-row
`vote_positions` table — and needs no extra dependency or query-cost guardrail. It also
fits the repo's raw-SQL / no-ORM grain. Trade-off accepted: a new analysis means a new view
+ redeploy.

## How it works

**Three plain views** (`vote_party_breakdown`, `vote_totals`, `member_voting_summary`) are
computed at read time. Their normal filtered access paths hit existing indexes
(`idx_positions_vote_party`, `idx_positions_vote_id`, `idx_positions_bioguide`) — no new
indexes needed.

**Voting similarity** is the one case that can't be computed per-request — it's an
O(n²)-within-each-vote self-join. It's precomputed into a `vote_similarity` table
(`congress, chamber, member_a, member_b, shared_votes, agreed`, pairs stored once with
`member_a < member_b`) and maintained by the vote ingester:

- After each ingest, the ingester rebuilds the similarity rows for every congress whose vote
  data has changed since its last successful rebuild. Staleness is tracked per congress in a
  small internal `vote_similarity_state(congress, built_through)` table, keyed off
  `max(votes.updated_at)`.
- Each congress is rebuilt in its own transaction (`DELETE` + `INSERT` + watermark advance),
  so readers always see a complete partition and the watermark only advances on success.
- This is **self-correcting**: a rebuild that fails or is interrupted leaves its watermark
  unadvanced, so it's detected as stale and retried on the next run — no manual intervention.
  On a fresh database the first full ingest backfills every congress; in steady state only
  the current congress is stale, so the recurring cost is one congress's rebuild (and a cheap
  staleness query when nothing changed).

The agreement ratio (`agreed / sharedVotes`) and any minimum-shared-votes threshold are left
to the consumer; the table stays a raw count table.

### A note on the `vote_similarity_state` table

I've added a second, internal table alongside `vote_similarity`:

```
CREATE TABLE vote_similarity_state (
  congress      SMALLINT    PRIMARY KEY,
  built_through TIMESTAMPTZ NOT NULL
);
```

It records, per congress, the `max(votes.updated_at)` that congress's similarity rows were last successfully built from. That single watermark is what makes the rebuild self-correcting: each run rebuilds any congress whose current `max(votes.updated_at)` exceeds its `built_through` (or has no row yet), and the watermark is advanced only inside the successful rebuild transaction. So a failed or interrupted rebuild leaves `built_through` behind and is retried on the next run, with no dependence on what was ingested. It's marked `@omit`, so it isn't exposed through GraphQL — it's purely ingester bookkeeping, like `ingestion_runs`.

## Example queries

Party breakdown of a vote:
```graphql
{ allVotePartyBreakdowns(filter: { voteId: { equalTo: "s83-119.2025" } }) {
    nodes { party position positions } } }
```

A member's cloture record this congress:
```graphql
{ allMemberVotingSummaries(filter: {
    bioguideId: { equalTo: "W000817" }, congress: { equalTo: 119 }, category: { equalTo: "cloture" }
  }) { nodes { position positions } } }
```

A member's closest allies in a congress:
```graphql
{ allVoteSimilarities(
    filter: { congress: { equalTo: 119 }, chamber: { equalTo: "s" }, memberA: { equalTo: "W000817" } }
    orderBy: AGREED_DESC, first: 5
  ) { nodes { memberB sharedVotes agreed } } }
```

## Testing

Verified against a local Postgres + the PostGraphile server:

- All four connections are exposed with working `filter` / `orderBy`; counts return as `Int`.
- Aggregation results match direct `SELECT … GROUP BY` checks (party split, member summary,
  totals, and the pairwise-agreement math — pairs deduped via `member_a < member_b`).
- **No regression:** the docs site's existing similarity demo (`first: 30000`) and the nested
  nominations queries still succeed — nothing constrains existing query shapes.
- **Similarity maintenance:**
  - Backfill — a fresh DB with multiple congresses populates all of them; each congress's
    partition is independent.
  - Incremental — adding a vote to one congress and rebuilding rebuilds only that congress;
    other congresses are untouched.
  - Self-correction — a simulated rebuild failure for one congress is detected as stale and
    retried on the next run **without** re-ingestion; a run with nothing stale does zero
    rebuilds.
  - Atomicity — the per-congress `DELETE`+`INSERT` is one transaction, so a concurrent read
    never sees a half-built partition.

## Docs

`us-congress/docs/docs/schema/index.md` gains an **Aggregation** section documenting all four
connections with examples and the `memberA < memberB` pairing caveat.

## Out of scope / follow-ups

- **Repointing the frontend similarity demo** (`VotingSimilarityGraph`) from its in-browser
  `first: 30000` computation to `allVoteSimilarities` — a separate frontend change; this PR
  only *adds* the data without touching the existing demo. (Issue filed as #41)
- **A party-defectors helper view** (member vs. party majority) — future work; today it's a
  two-step query over `vote_party_breakdown`.
- **Unrelated bug filed separately:** the Postgres `initdb` scripts run out of order
  (`99-grafana-reader.sh` before `schema.sql`), so `schema.sql` is skipped on a fresh volume.
  Tracked in its own issue (#39).