### PR TITLE
docs: note nginx restart when a deploy recreates the server container

### DIFF
--- a/us-congress/README.md
+++ b/us-congress/README.md
@@ -304,3 +304,11 @@ dotenvx run -- docker compose up -d --build
 Flyway runs the new `db/migrations/V*.sql`, then the API server restarts and re-introspects the schema. If the change touched documented tables, also rebuild the docs site (see [Deploying changes to Docusaurus site](#deploying-changes-to-docusaurus-site)).
 
 > **First time only:** this production database predates Flyway, so run the one-time `baseline` (see [Adopting Flyway on an existing database](#adopting-flyway-on-an-existing-database-one-time)) **before** the first `up` that includes the `flyway` service — otherwise Flyway would try to recreate the existing schema and fail.
+
+> **502 after the deploy?** If the `up` **recreated** the `server` container (e.g. the postgres container was also recreated, which chains a server recreate), nginx may still be proxying to the old container's IP — it resolves the `server` hostname at startup and caches it. The fix is to bounce nginx so it re-resolves:
+>
+> ```bash
+> docker compose restart nginx
+> ```
+>
+> A routine schema-only deploy that merely restarts `server` in place won't usually trigger this; a deploy that *recreates* `server` (container config change, image rebuild, or a postgres recreate) will.


### PR DESCRIPTION
## Why

During the Flyway production cutover, the API returned `502 Bad Gateway` even though the `server` container was healthy and serving on :4000. Cause: the `up` recreated the `server` container (the initdb-mount change recreated postgres, which chained a server recreate), and nginx — which resolves the `server` hostname at startup and caches the IP — kept proxying to the now-dead old container. `docker compose restart nginx` fixed it instantly.

## What

Adds a caveat to the **Deploying schema changes** section of `us-congress/README.md` documenting the symptom and the one-line fix, and noting that routine schema-only deploys (which only restart `server` in place) won't usually trigger it — only deploys that *recreate* `server` will.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)