### PR TITLE
Harden server against probing (#36)

### DIFF
--- a/us-congress/CHANGELOG.md
+++ b/us-congress/CHANGELOG.md
@@ -32,6 +32,10 @@ Change categories: **Added** (new capabilities), **Changed** (changes to existin
 
 ## [Unreleased]
 
+### Security
+
+- Hardened the service against automated abuse and probing. (#36)
+
 ## [2026-06-25]
 
 ### Added

--- a/us-congress/README.md
+++ b/us-congress/README.md
@@ -312,3 +312,61 @@ Flyway runs the new `db/migrations/V*.sql`, then the API server restarts and re-
 > ```
 >
 > A routine schema-only deploy that merely restarts `server` in place won't usually trigger this; a deploy that *recreates* `server` (container config change, image rebuild, or a postgres recreate) will.
+
+## Hardening against probing
+
+The box is continuously probed by automated scanners (raw-IP TLS handshakes, WordPress/PHP
+webshell paths, etc.). None of it is a breach, but the defaults let it through noisily. The
+nginx config (`nginx/nginx.conf`) handles the bulk of it cheaply:
+
+- **Real 404s.** Unknown paths return a real `404` (the themed Docusaurus 404 page) instead of
+  silently serving the homepage with a `200`. This stops advertising "everything exists" to
+  scanners and makes the logs meaningful — a successful probe is now distinguishable from a
+  failed one.
+- **Refusing junk.** Known probe paths (`/wp-admin`, `/wp-login`, …) and server-side script
+  extensions (`.php`, `.asp`, `.jsp`, `.env`, …) get `444` (connection closed, no response).
+  Nothing here is WordPress or a scripting runtime, so these can never be legitimate.
+- **Rate limiting.** Per-IP request and connection limits (`limit_req` / `limit_conn`) cap
+  abusive bursts and return `429`. The static site's limits are generous (a page load pulls many
+  assets at once, and immutable `/assets/` + `/img/` are exempt from request throttling); the API
+  limit is a coarse flood shield in front of PostGraphile's own finer 100 req/min per-IP limiter.
+- **Refusing raw-IP / unknown-host TLS.** A `:443` `default_server` with `ssl_reject_handshake`
+  rejects TLS handshakes that don't match a hostname we serve, so scanners hitting the raw IP
+  never get a request processed.
+
+The host firewall (`ufw`, see [Root-only setup](#1-root-only-setup)) already limits inbound to
+22/80/443, which covers the firewall-minimization side of hardening.
+
+### Deferred next layers (not yet implemented)
+
+These are higher-effort layers that live in infrastructure/account configuration rather than this
+repo. Documented here so the rationale isn't lost:
+
+- **Dynamic IP-blocking (fail2ban / CrowdSec).** Useful for shedding *repeat* offenders at the
+  kernel firewall and cutting log noise, but a *next* layer — the nginx rules plus the app's
+  per-IP limiter already absorb most of the volume. Classic **fail2ban fits this stack poorly**:
+  it wants a host log file, but our logs go straight to stdout → Vector → Loki (no file on disk),
+  and it's per-IP, so it can't touch the distributed/rotating cloud-IP scanning that dominates the
+  traffic. If we adopt dynamic blocking, prefer **CrowdSec** — it reads container logs over the
+  Docker socket (no host log file), runs as a Compose service, has decoupled "bouncers"
+  (host-firewall / in-nginx / Cloudflare), and ships crowdsourced blocklists that *do* cover
+  distributed scanners.
+- **Cloudflare (highest-value next move).** Putting the site behind Cloudflare hides the origin
+  IP (so raw-IP scanning can be firewalled off entirely), uses edge reputation to handle
+  distributed scanners, and edge-caches the static site. It's an infrastructure migration, not a
+  code change, with prerequisites worth planning for:
+  1. **DNS / certs.** The proxy requires Cloudflare to serve the proxied records, which breaks the
+     current acme.sh **Gandi DNS-01** wildcard issuance (see [Obtain a wildcard TLS
+     certificate](#5-obtain-a-wildcard-tls-certificate)). Switch to Cloudflare's DNS-01 plugin, or
+     use a Cloudflare **Origin CA** cert on the origin with SSL mode **Full (strict)**.
+  2. **Real client IP.** Once proxied, nginx sees Cloudflare's IP. Add `set_real_ip_from <CF
+     ranges>` + `real_ip_header CF-Connecting-IP` (realip module) so the rate limits **and** the
+     API's `X-Forwarded-For` logic still see the true client — otherwise every visitor collapses
+     to a handful of Cloudflare IPs and both limiters misbehave.
+  3. **Origin lockdown.** Restrict the host firewall to Cloudflare's IP ranges, or scanners simply
+     hit the raw IP and bypass the edge.
+  4. **API subdomain.** Disable caching for `api.govql.us` (dynamic GraphQL); Cloudflare's free
+     100s edge timeout is fine against the 30s `proxy_read_timeout`.
+
+  The free tier covers DDoS mitigation, Bot Fight Mode, a few custom WAF rules, and one basic
+  rate-limiting rule; the managed OWASP ruleset requires a paid plan.

--- a/us-congress/ingester/ingest_cron
+++ b/us-congress/ingester/ingest_cron
@@ -1,5 +1,8 @@
+# Job output is sent to PID 1's stdout/stderr (crond -f) so it flows to the
+# container's logs → Vector → Loki, like every other service.
+
 # Ingest legislators once per day at 02:15 (scraper runs legislators at 02:00).
-15 2 * * * . /etc/environment; cd /app && node src/ingest-legislators.js >> /var/log/ingest.log 2>&1
+15 2 * * * . /etc/environment; cd /app && node src/ingest-legislators.js > /proc/1/fd/1 2>/proc/1/fd/2
 
 # Ingest votes every hour at :50 (scraper runs votes at :35; 15-min buffer).
-50 * * * * . /etc/environment; cd /app && node src/ingest-votes.js >> /var/log/ingest.log 2>&1
+50 * * * * . /etc/environment; cd /app && node src/ingest-votes.js > /proc/1/fd/1 2>/proc/1/fd/2

--- a/us-congress/nginx/nginx.conf
+++ b/us-congress/nginx/nginx.conf
@@ -12,6 +12,20 @@ ssl_prefer_server_ciphers off;
 ssl_session_cache         shared:SSL:10m;
 ssl_session_timeout       1d;
 
+# ── Rate-limiting zones (http context) ────────────────────────────────────────
+# This file is included within nginx's http{} block (conf.d/*.conf), so the
+# zone definitions live here alongside the shared ssl_* settings above.
+# Keyed on client IP. The static site is generous (a single page pulls many
+# assets); the API zone is a coarse flood shield only — PostGraphile already
+# enforces a finer 100 req/min per-IP limit and query depth/complexity budgets.
+limit_req_zone  $binary_remote_addr zone=static:10m rate=30r/s;
+limit_req_zone  $binary_remote_addr zone=api:10m    rate=20r/s;
+limit_conn_zone $binary_remote_addr zone=conn:10m;
+# Return 429 (not the default 503) when a limit trips, so throttling isn't
+# misread as a backend outage by uptime monitoring.
+limit_req_status  429;
+limit_conn_status 429;
+
 # ── HTTP: redirect everything to HTTPS ────────────────────────────────────────
 server {
     listen 80;
@@ -22,10 +36,23 @@ server {
     }
 }
 
+# ── HTTPS: refuse raw-IP / unknown-host TLS ───────────────────────────────────
+# Default server for :443. Scanners that connect by raw IP (no SNI) or with a
+# hostname we don't serve hit this block and get their TLS handshake rejected
+# outright — no cert is presented and no request is processed. Named servers
+# below still win for matching SNI (govql.us, www.govql.us, api.govql.us).
+server {
+    listen 443 ssl default_server;
+    ssl_reject_handshake on;
+}
+
 # ── HTTPS: static site (govql.us) ─────────────────────────────────────────────
+# www.govql.us is listed explicitly (it's the canonical host and resolves via a
+# CNAME) so it keeps matching here rather than falling through to the reject
+# block above.
 server {
     listen 443 ssl;
-    server_name govql.us;
+    server_name govql.us www.govql.us;
 
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
     add_header X-Content-Type-Options nosniff always;
@@ -34,11 +61,38 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Cap concurrent connections per IP (generous — shared NAT/CGNAT egress can
+    # put many real users behind one address).
+    limit_conn conn 24;
+
+    # Refuse common probe paths/extensions outright. This stack serves only a
+    # static Docusaurus site and a GraphQL API — nothing here is WordPress or a
+    # server-side script, so these can never be legitimate. 444 closes the
+    # connection with no response. Regex locations take precedence over the
+    # `location /` prefix match below.
+    location ~* ^/(wp-admin|wp-content|wp-includes|wp-login) { return 444; }
+    location ~* \.(php|asp|aspx|jsp|cgi|pl|sh|env|sql|bak)$  { return 444; }
+
+    # Immutable, content-hashed build assets. Exempt from request-rate limiting
+    # so a normal page load (which pulls many of these at once) is never
+    # throttled; they still inherit limit_conn and the security headers above.
+    location /assets/ { }
+    location /img/    { }
+
     location / {
-        # Docusaurus generates static HTML for all routes, but this fallback
-        # handles direct navigation to any path gracefully.
-        try_files $uri $uri/ $uri.html /index.html;
+        # Docusaurus pre-renders static HTML for every real route, so genuine
+        # paths resolve via $uri / $uri/ / $uri.html. Anything left is a path
+        # that does not exist — return a real 404 (not the homepage), which
+        # keeps the logs meaningful and stops advertising "everything exists".
+        try_files $uri $uri/ $uri.html =404;
+
+        # Throttle bursts of document requests; generous burst so legitimate
+        # navigation is unaffected.
+        limit_req zone=static burst=60 nodelay;
     }
+
+    # Serve Docusaurus's themed 404 page (built to the root) with a real 404.
+    error_page 404 /404.html;
 }
 
 # ── HTTPS: GraphQL API (api.govql.us) ─────────────────────────────────────────
@@ -49,7 +103,18 @@ server {
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
     add_header X-Content-Type-Options nosniff always;
 
+    limit_conn conn 20;
+
+    # Same probe-path refusal as the static site (location blocks aren't shared
+    # across servers, so they're repeated here). These can't match the API's
+    # extensionless POST /graphql endpoint.
+    location ~* ^/(wp-admin|wp-content|wp-includes|wp-login) { return 444; }
+    location ~* \.(php|asp|aspx|jsp|cgi|pl|sh|env|sql|bak)$  { return 444; }
+
     location / {
+        # Coarse flood shield in front of PostGraphile's own per-IP limiter.
+        limit_req zone=api burst=40 nodelay;
+
         proxy_pass         http://server:4000;
         proxy_http_version 1.1;
 

--- a/us-congress/scraper/scrape_cron
+++ b/us-congress/scraper/scrape_cron
@@ -1,5 +1,7 @@
 # Source container environment so HEALTHCHECK_* vars are available.
+# Job output is sent to PID 1's stdout/stderr (cron -f) so it flows to the
+# container's logs → Vector → Loki, like every other service.
 SHELL=/bin/sh
 
-35 * * * * root . /etc/environment; cd /congress && /usr/local/bin/usc-run votes --force >> /var/log/cron.log 2>&1 && [ -n "$HEALTHCHECK_VOTES_SCRAPE_URL" ] && curl -fsS --retry 3 "$HEALTHCHECK_VOTES_SCRAPE_URL" > /dev/null 2>&1; true
-0  2 * * * root /usr/local/bin/update-legislators.sh >> /var/log/cron.log 2>&1
+35 * * * * root . /etc/environment; cd /congress && /usr/local/bin/usc-run votes --force > /proc/1/fd/1 2>/proc/1/fd/2 && [ -n "$HEALTHCHECK_VOTES_SCRAPE_URL" ] && curl -fsS --retry 3 "$HEALTHCHECK_VOTES_SCRAPE_URL" > /dev/null 2>&1; true
+0  2 * * * root /usr/local/bin/update-legislators.sh > /proc/1/fd/1 2>/proc/1/fd/2


### PR DESCRIPTION
Closes #36

Probing scanners were being served the homepage with `200` for any path (the `try_files … /index.html` fallback), which both invited more probing and made the logs meaningless. This hardens the edge and fixes two services whose logs never reached our pipeline.

## nginx (`nginx/nginx.conf`)
- **Real 404s** — unknown paths return a real `404` (themed Docusaurus 404 page) via `=404` + `error_page 404 /404.html`, instead of silently serving the homepage.
- **Refuse junk** — known probe paths (`wp-*`) and script extensions (`.php`, `.asp`, `.jsp`, `.env`, …) get `444` (connection closed) on both the static and API servers.
- **Rate limiting** — per-IP `limit_req`/`limit_conn` returning `429`; generous on the static site with immutable `/assets/` + `/img/` exempt so real page loads aren't throttled, coarse on the API in front of PostGraphile's own 100 req/min per-IP limiter.
- **Refuse raw-IP / unknown-host TLS** — a `:443` `default_server` with `ssl_reject_handshake`; `www.govql.us` added to `server_name` so the canonical host keeps matching rather than hitting the reject block.

## Logging fix (`scraper/scrape_cron`, `ingester/ingest_cron`)
Both cron jobs redirected output to a container-internal file (`/var/log/*.log`), so their logs never reached Vector → Loki (and grew unbounded). Now sent to PID 1's stdout/stderr, matching every other service.

## Docs
- README gains a **Hardening against probing** section describing the above and the deferred next layers — **fail2ban/CrowdSec** (why deferred; CrowdSec preferred for this containerized stack) and **Cloudflare** (recommended infra next step, with DNS/cert, real-IP, and origin-lockdown prerequisites).
- CHANGELOG: one general `Security` line (it's consumer-facing-only; internal/deployment details intentionally omitted).

## Validation
`nginx -t` passes in a `nginx:1.27-alpine` container with stub certs + a stubbed `server` upstream (a bare local `nginx -t` can't — it's a `conf.d` snippet that resolves the upstream and opens certs at load time). Full deploy steps + curl/Loki verification + rollback are in the plan's deployment runbook; key gotcha: the nginx config is bind-mounted (restart), but the scraper/ingester cron files are baked into their images and **must be rebuilt** (`--build`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)