### PR TITLE
docs: add master plan scaffolding for ingestion architecture (Part of #56)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,16 @@ per-package `README.md` files, which this document links to for detail.
 When a new cross-cutting convention is decided, add it here so future sessions
 inherit it.
 
+## Active plan
+
+The project's master plan lives at [`plans/PLAN.md`](plans/PLAN.md) — a durable
+architectural header plus an ordered list of task pointers (task bodies in
+`plans/tasks/`, finished ones in `plans/tasks/done/`). It is kept here, in
+`AGENTS.md` and a generic `plans/` directory rather than a Claude-specific
+`CLAUDE.md`, so the planning workflow stays usable across Claude, Codex, and
+OpenCode. New work is appended by the `to-plan` workflow; it never creates a
+second plan.
+
 ## Repository map
 
 - **`us-congress/`** — US Congress roll-call vote data, served as a GraphQL API

--- a/plans/PLAN.md
+++ b/plans/PLAN.md
@@ -1,0 +1,75 @@
+# Plan: GovQL
+
+> Source: GitHub issue #56 (generalize ingestion architecture) + talk-it-through 2026-06-30.
+
+This is the project's master plan: a durable architectural header plus an ordered
+list of task pointers. Each task is one feature on its own branch, ending in a PR.
+Task bodies live in `plans/tasks/`; finished tasks move to `plans/tasks/done/`.
+
+This file lives in a generic `plans/` directory and is pointed to from `AGENTS.md`
+("Active plan") rather than a Claude-specific `CLAUDE.md`, so the workflow stays
+usable across Claude, Codex, and OpenCode.
+
+**PR convention for these tasks**: issue #56 is a *tracking* issue spanning steps
+1–5; this plan only implements steps 1+2. Each task's PR must **reference** #56
+(e.g. `Part of #56`) and must **not** close it (no `Closes #56`). Steps 3–5 get a
+fresh follow-up issue.
+
+## Workflow
+
+- New work is added by the `to-plan` skill: a self-contained task file under
+  `plans/tasks/NNNN-<slug>.md` plus a pointer below. It appends; it never creates a
+  second plan.
+- `implement-next-task` takes the first eligible pointer (or an explicit task
+  argument), builds it on its branch — AFK via `tdd`, `[decision]` via
+  `talk-it-through`, `[verify]` paused for manual confirmation — runs `task-review`,
+  then opens the PR after approval and flips the pointer to `[>]`.
+- A pointer has four states: `[ ]` todo · `[~]` in progress (claimed) · `[>]` done,
+  PR open, awaiting merge · `[x]` merged to `main`. `sync-main` flips `[>]→[x]` and
+  moves the task file to `tasks/done/` once the PR merges.
+- Pointers carry their direct prerequisites as an `(after NNNN, …)` suffix (none =
+  no suffix). A task is selectable only once every ordinal in its `(after …)` list is
+  `[x]` (merged).
+
+## Architectural decisions
+
+Durable decisions that apply across all tasks:
+
+- **Monorepo**: `us-congress/` (PostGraphile v5 GraphQL API over PostgreSQL, plus
+  cron-based scraper/ingester services and a Docusaurus docs site, orchestrated with
+  Docker Compose) and `mcp-server/` (Python/FastMCP). Deployed independently.
+- **Schema**: managed by **Flyway** migrations in `us-congress/db/migrations/`
+  (`Vnnn__description.sql`, zero-padded, immutable once applied). Per-table API docs
+  are **generated from the migration SQL** by `docs/scripts/generate-schema-docs.mjs`
+  — the repo's "generate docs from the executable source of truth" idiom.
+- **Ingestion model (retained)**: lightweight **cron** scrape→ingest, joined by a
+  shared file volume; idempotent upserts on natural keys (`ON CONFLICT`);
+  `ingestion_runs` audit log. A Postgres-backed queue (pg-boss or graphile-worker) is
+  **deferred** until real fan-out / retry-with-backoff / concurrent-backfill pressure
+  arrives; pg-boss is a co-equal/arguably-preferred candidate to graphile-worker.
+- **Staged cursors**: ingestion is modeled as three decoupled, independently-gated,
+  independently-watermarked stages — `fetch` (scrape) → `load` (ingest raw) →
+  `build` (aggregates). A generic `source_state(source_name, stage, cursor TIMESTAMPTZ)`
+  table holds the `fetch`/`load` cursors. **Readiness handshake**: `load.cursor` = the
+  `fetch.cursor` value the load has fully consumed (read at start, written on success);
+  load runs iff `fetch.cursor > load.cursor` (or `load.cursor IS NULL`). The `build`
+  stage keeps its existing per-congress `vote_similarity_state` watermark.
+- **Gating rule**: an **opaque/external** input (scrape files, an API) → **cursor
+  handshake** in `source_state`. An **owned DB table** (has `updated_at`) →
+  **staleness comparison**: rebuild when `GREATEST(inputs.updated_at) > built_through`,
+  which fans in over multiple inputs for free. No generic DAG/edge table yet.
+- **Implicit-DAG documentation**: the pipeline graph is a maintained artifact.
+  `us-congress/ingester/pipeline.manifest.js` is the single source of truth (one node
+  per stage, `upstream[]` = edges); `generate-pipeline-docs.mjs` renders a stamped
+  `us-congress/PIPELINE.md` (Mermaid + node table); a `--check` mode validates the
+  manifest against the crontabs and migrations and that `PIPELINE.md` is fresh.
+  Adding a source or aggregation requires updating the manifest + regenerating
+  (the ritual is recorded in `AGENTS.md`). Runnable via `npm run` only for now;
+  CI/CD enforcement is a separate future issue.
+
+---
+
+## Tasks
+
+- [ ] 0001 · source_state cursor, fetch→load readiness, decoupled build stage → tasks/0001-source-state-cursor-decoupled-stages.md
+- [ ] 0002 · Pipeline DAG manifest, generator + drift validator (after 0001) → tasks/0002-pipeline-dag-manifest.md

--- a/plans/tasks/0001-source-state-cursor-decoupled-stages.md
+++ b/plans/tasks/0001-source-state-cursor-decoupled-stages.md
@@ -1,0 +1,42 @@
+# Task 0001: source_state cursor, fetch→load readiness, decoupled build stage
+
+**Branch**: `feature/source-state-cursor-decoupled-stages`
+**Depends on**: none
+**Source**: GitHub issue #56 (steps 1+2) · talk-it-through 2026-06-30 · **User stories**: as the data platform, I want each ingestion stage to gate on an explicit upstream cursor instead of a wall-clock buffer, and to run aggregates as their own job, so adding sources doesn't depend on cron timing luck.
+**PR**: reference #56 (`Part of #56`); do **not** close it — it's a tracking issue spanning steps 1–5.
+
+## What to build
+
+Reshape the `us-congress` ingestion pipeline from "scrape at :35, ingest at :50 (15-min buffer), build aggregates in the same process" into three decoupled, cursor-gated stages — `fetch` → `load` → `build` — for both existing sources (votes, legislators).
+
+- A generic `source_state(source_name, stage, cursor TIMESTAMPTZ)` table holds the `fetch` and `load` cursors (the `build` stage keeps its existing per-congress `vote_similarity_state` watermark, untouched).
+- The **scraper** gains DB access and, on each successful scrape, UPSERTs its `fetch` cursor = `now()`.
+- Each **ingester** reads its source's `fetch` cursor at the start of a run, **skips** (clean no-op, exit 0, logged) when `fetch.cursor` has not advanced past `load.cursor`, and on a successful full run advances `load.cursor` to the `fetch.cursor` value it captured at the start. Existing per-record `needsIngestion()` skip logic and all `ON CONFLICT` idempotency are preserved.
+- Aggregate building is split out of `ingest-votes.js` into a new `build-aggregates.js` with its own cron schedule and its own `ingestion_runs` row; `staleCongresses()` / `rebuildAggregatesForCongress()` / the `vote_similarity_state` watermark semantics move verbatim and stay self-gating.
+
+The readiness handshake — not the cron time — is the correctness gate; cron times become a soft schedule only. See the master plan's "Staged cursors" decision for the durable cursor semantics.
+
+## AFK tasks
+
+- [ ] Add `V003__source_state.sql`: `source_state(source_name TEXT, stage TEXT CHECK (stage IN ('fetch','load')), cursor TIMESTAMPTZ, updated_at TIMESTAMPTZ DEFAULT now(), PRIMARY KEY (source_name, stage))`, with an `@omit` table comment (internal, like `vote_similarity_state`). It holds no secrets, so the blanket `grafana_reader` SELECT is fine — no REVOKE needed.
+- [ ] Re-run `npm run generate-schema-docs`; confirm the `@omit` table is excluded from / handled by the generated schema docs (match how `vote_similarity_state` is treated).
+- [ ] Add a small reusable cursor helper (read `fetch`/`load` cursor for a source; advance `load` cursor to a captured value) used by both ingesters; write `node:test` unit tests for the pure readiness predicate (`run iff fetch.cursor > load.cursor or load.cursor IS NULL`, else skip).
+- [ ] `ingest-votes.js`: at run start read `congress-votes` `fetch` cursor; if not ready, log and exit 0 without walking; on success advance the `load` cursor to the captured `fetch` value. Remove the aggregate-build section (moves to `build-aggregates.js`).
+- [ ] `ingest-legislators.js`: same `fetch`→`load` readiness gate + `load` cursor advance for `congress-legislators`.
+- [ ] New `build-aggregates.js`: move `staleCongresses()` + `rebuildAggregatesForCongress()` + the per-congress rebuild loop here, with its own `ingestion_runs` row (`run_type = 'vote_aggregates'`) and the votes-ingest healthcheck split appropriately. Logic and `vote_similarity_state` semantics unchanged.
+- [ ] Scraper container: add `postgresql-client` to `scraper/Dockerfile`; add `DATABASE_URL` to the `scraper` service in `compose.yml`. After each successful scrape, UPSERT the `fetch` cursor (`now()`) via `psql` — for the votes cron line and in/after `update-legislators.sh` — only on success.
+- [ ] Ingester crontab: keep the votes `load` and legislators `load` lines (soft schedule), add a `build-aggregates.js` line scheduled after the votes load. Remove any reliance on the old "15-min buffer" comment/coupling.
+- [ ] Add `node:test` test scripts to `ingester/package.json` (`node --test`) so the readiness/cursor logic is covered without new deps.
+
+## Human-in-the-loop tasks
+
+- [ ] [verify] On a real `docker compose -f compose.yml -f compose.dev.yml up`, trigger a scrape and confirm end-to-end: the scraper writes the `fetch` cursor to `source_state`; each ingester **skips** when the `fetch` cursor hasn't advanced and **runs + advances `load`** when it has; `build-aggregates.js` runs as its own cron job and rebuilds only stale congresses. — Cron scheduling, container env-sourcing (`printenv > /etc/environment`), and cross-container DB writes can't be exercised by `node:test`, and the repo has no docker-based integration harness or CI yet (CI is a separate future issue).
+
+## Acceptance criteria
+
+- [ ] `V003__source_state.sql` applies cleanly via the `flyway` service; `source_state` is `@omit`'d from the GraphQL schema.
+- [ ] On a successful scrape, the scraper writes a `fetch` cursor row for `congress-votes` and `congress-legislators`.
+- [ ] Each ingester exits 0 with a clear log line when `fetch.cursor` has not advanced past `load.cursor`, and otherwise runs and advances `load.cursor` to the captured `fetch.cursor` only after a successful run (crash mid-run leaves `load.cursor` unadvanced → next run re-checks ready and re-walks idempotently).
+- [ ] Aggregates are built by `build-aggregates.js` as a separate cron job; `ingest-votes.js` no longer builds aggregates; `vote_similarity_state` staleness/rebuild behavior and `needsIngestion()` per-record skipping are unchanged.
+- [ ] No wall-clock dependency remains between scrape and ingest — the readiness check is the only correctness gate; cron times are documented as a soft schedule.
+- [ ] `node:test` covers the readiness predicate and cursor-advance logic and passes via `npm test` in `ingester/`.

--- a/plans/tasks/0001-source-state-cursor-decoupled-stages.md
+++ b/plans/tasks/0001-source-state-cursor-decoupled-stages.md
@@ -1,6 +1,6 @@
 # Task 0001: source_state cursor, fetch→load readiness, decoupled build stage
 
-**Branch**: `feature/source-state-cursor-decoupled-stages`
+**Branch**: `56-source-state-cursor-decoupled-stages`
 **Depends on**: none
 **Source**: GitHub issue #56 (steps 1+2) · talk-it-through 2026-06-30 · **User stories**: as the data platform, I want each ingestion stage to gate on an explicit upstream cursor instead of a wall-clock buffer, and to run aggregates as their own job, so adding sources doesn't depend on cron timing luck.
 **PR**: reference #56 (`Part of #56`); do **not** close it — it's a tracking issue spanning steps 1–5.

--- a/plans/tasks/0002-pipeline-dag-manifest.md
+++ b/plans/tasks/0002-pipeline-dag-manifest.md
@@ -1,6 +1,6 @@
 # Task 0002: Pipeline DAG manifest, generator + drift validator
 
-**Branch**: `feature/pipeline-dag-manifest`
+**Branch**: `56-pipeline-dag-manifest`
 **Depends on**: 0001
 **Source**: GitHub issue #56 · talk-it-through 2026-06-30 · **User stories**: as a maintainer adding new sources/aggregations, I want the implicit cron+cursor DAG to be a generated, validated artifact, so the pipeline stays understandable and the docs can't silently drift from what actually runs.
 **PR**: reference #56 (`Part of #56`); do **not** close it — it's a tracking issue spanning steps 1–5.

--- a/plans/tasks/0002-pipeline-dag-manifest.md
+++ b/plans/tasks/0002-pipeline-dag-manifest.md
@@ -1,0 +1,32 @@
+# Task 0002: Pipeline DAG manifest, generator + drift validator
+
+**Branch**: `feature/pipeline-dag-manifest`
+**Depends on**: 0001
+**Source**: GitHub issue #56 · talk-it-through 2026-06-30 · **User stories**: as a maintainer adding new sources/aggregations, I want the implicit cron+cursor DAG to be a generated, validated artifact, so the pipeline stays understandable and the docs can't silently drift from what actually runs.
+**PR**: reference #56 (`Part of #56`); do **not** close it — it's a tracking issue spanning steps 1–5.
+
+## What to build
+
+Make the implicit ingestion DAG an explicit, maintained artifact, following the repo's "generate docs from the executable source of truth" idiom (mirrors `generate-schema-docs.mjs`). Depends on 0001 because the manifest must describe the post-0001 reality (the `fetch`/`load`/`build` stages, `source_state`, the new `build-aggregates` cron line).
+
+- `ingester/pipeline.manifest.js` — the single source of truth: one node per stage (`scrape-votes`/`ingest-votes`/`build-aggregates`/`scrape-legislators`/`ingest-legislators`), each `{ id, stage, domain, upstream[], reads[], writes[], trigger{cron, readiness}, watermark{table, key, advances}, idempotency }`. `upstream[]` is the DAG's edge set.
+- `generate-pipeline-docs.mjs` — renders a stamped, internal `us-congress/PIPELINE.md` (a Mermaid `graph LR` of nodes/edges + a per-node table). Lives next to `README.md`, **not** on the consumer Docusaurus site (per the changelog scope rule, scraper/ingester internals aren't consumer-facing).
+- A `--check` mode on the generator that **fails (non-zero)** on drift: every manifest node with a `trigger.cron` matches a line in `ingester/ingest_cron` / `scraper/scrape_cron` and vice-versa; every table named in `reads`/`writes`/`watermark` exists in the migrations (reuse the schema-docs migration parser); and `PIPELINE.md` is up to date (regenerate to memory, diff). Runnable via `npm run` only — no CI runner yet (option B).
+- The upkeep ritual recorded in `AGENTS.md`.
+
+## AFK tasks
+
+- [ ] Write `ingester/pipeline.manifest.js` enumerating the five current nodes with their `upstream[]` edges and the fields above, reflecting the post-0001 crontabs, `source_state` cursors, and `vote_similarity_state` build watermark.
+- [ ] Write `generate-pipeline-docs.mjs` (sibling pattern to `generate-schema-docs.mjs`, with a stamped "generated — do not edit" header) that renders `us-congress/PIPELINE.md` with a Mermaid `graph LR` + a per-node table.
+- [ ] Implement `--check`: parse both crontabs and assert manifest↔crontab parity; parse `db/migrations/` and assert all referenced tables exist; regenerate `PIPELINE.md` to memory and fail if it differs from the committed file.
+- [ ] Add `npm run generate-pipeline-docs` and a `--check` invocation to `ingester/package.json` (use relative paths to reach `../scraper/scrape_cron` and `../db/migrations`); add `node:test` tests covering the validator: a consistent manifest passes; an extra/missing crontab node fails; a referenced non-existent table fails; a stale `PIPELINE.md` fails.
+- [ ] Generate and commit `us-congress/PIPELINE.md`.
+- [ ] Add the ritual to `AGENTS.md`: "Adding a data source or aggregation? Add its node(s) to `ingester/pipeline.manifest.js` using the standard fields, run `npm run generate-pipeline-docs`, and commit the regenerated `PIPELINE.md`; `--check` validates the manifest against the crontabs and schema." Cross-reference the master plan's "Staged cursors" and "Gating rule" decisions.
+
+## Acceptance criteria
+
+- [ ] `pipeline.manifest.js` enumerates all current pipeline nodes and their dependency edges.
+- [ ] `npm run generate-pipeline-docs` produces `us-congress/PIPELINE.md` with a Mermaid DAG and a per-node table, carrying a generated-file header.
+- [ ] `--check` exits non-zero when (a) a crontab job has no manifest node or vice-versa, (b) a referenced table is absent, or (c) `PIPELINE.md` is stale; and exits zero when everything is consistent.
+- [ ] `AGENTS.md` documents the add-a-source/aggregation ritual.
+- [ ] `node:test` covers the validator's pass and fail cases and passes via `npm test` in `ingester/`.


### PR DESCRIPTION
Lands the planning scaffolding for the ingestion-architecture work on `main` so the plan is discoverable from every task branch.

## What this adds
- `plans/PLAN.md` — the project master plan: durable architectural header + ordered task pointers (steps 1+2 of issue #56).
- `plans/tasks/0001-*.md`, `plans/tasks/0002-*.md` — self-contained task bodies.
- `AGENTS.md` — an "Active plan" pointer to `plans/PLAN.md`.

Task `Branch` fields use the repo's issue-prefixed `56-<slug>` convention so each task's branch/PR ties back to #56.

## Scope
Docs/process only — no code or schema changes. Subsequent PRs implement the tasks (each branched off `main`, each "Part of #56").

Part of #56. Does **not** close it — #56 is a tracking issue spanning steps 1–5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)