### PR TITLE
mcp-server v0.1.1: advertise derived analytics views in tool docs

### DIFF
--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to `govql-mcp-server` are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.1.1] — 2026-07-03
+
+### Changed
+
+- `execute_graphql` now points agents at the precomputed derived analytics
+  views (`VoteSimilarity`, `MemberPartyAgreement`, and the per-vote /
+  per-member tally views) so analytical questions use them directly instead of
+  aggregating raw `VotePosition` rows. Also nudges agents to run `list_types()`
+  before hand-rolling any multi-row computation, and calls out the derived
+  views in the `list_types` tip. Documentation only — no change to the tool
+  surface.
+
 ## [0.1.0] — 2026-05-28
 
 Initial release.

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -17,6 +17,7 @@ Ask an agent questions like:
 - *"Which legislators in the 118th Congress switched parties during their service?"*
 - *"Compare Senator Sanders' voting record to Senator Murkowski's on cloture votes
    in the most recent Congress."*
+- *"Which Democrats most often voted with Republicans in the current Congress?"*
 
 The agent picks the right tool, writes the GraphQL query against the live
 schema, and parses the response — no manual API wrangling.
@@ -101,7 +102,7 @@ Vote data refreshes hourly; legislator data refreshes daily.
 
 ## Status
 
-Version 0.1.0 ships three foundational tools: a GraphQL passthrough
+As of 0.1.1, the server provides three foundational tools: a GraphQL passthrough
 (`execute_graphql`) and two narrow schema-discovery tools (`list_types`,
 `describe_type`). Curated higher-level tools (`find_legislator`,
 `get_voting_record`, `compare_voters`, etc.) are planned for subsequent

--- a/mcp-server/docs/design.md
+++ b/mcp-server/docs/design.md
@@ -47,7 +47,7 @@ deliberate trade-off, weighed in the project's planning docs:
   schemas from Python type hints, which removes hundreds of lines of
   hand-written schema boilerplate that the TypeScript SDK would require.
 - FastMCP-Python ships an in-memory test client, so tests don't have to
-  spawn a subprocess and parse JSON-RPC manually. The whole 17-test suite
+  spawn a subprocess and parse JSON-RPC manually. The whole test suite
   runs in under a second.
 - The third-party `fastmcp` for TypeScript is a different author's wrapper
   that lags upstream — it didn't offer compelling enough ergonomics over
@@ -69,8 +69,37 @@ shipping one now would be cargo-cult engineering.
 
 ## Roadmap
 
-v0.1 ships the foundation. Each subsequent version is independently
-shippable and adds tools that fall into one of three categories:
+v0.1 ships the foundation. **v0.1.1** then closed a discoverability gap: with
+the derived analytics views now deployed in the data layer, `execute_graphql`
+points agents at them (`VoteSimilarity`, `MemberPartyAgreement`, and the
+per-vote / per-member tally views) so analytical questions use the precomputed
+views instead of brute-forcing over raw `VotePosition` rows.
+
+### Next up (before v0.2)
+
+Testing v0.1.1 against the motivating question — *"which two opposing-party
+members vote together most often?"* — showed the agent now finds `VoteSimilarity`
+but still struggles, because the table is **party-blind**: `member_a`/`member_b`
+are bare bioguide IDs with **no foreign key** to `legislators` (unlike
+`member_party_agreement`, which has one). So the type exposes no
+`legislatorByMemberA`/`legislatorByMemberB` relation, "opposing parties" can't be
+filtered server-side, and the agent falls back to fetching the whole (~96k-row
+for a House congress) pairwise slice and joining party client-side.
+
+- **[next task] Add `member_a`/`member_b` → `legislators` foreign keys to
+  `vote_similarity`** (small `us-congress` DB migration). Brings it in line with
+  `member_party_agreement` so PostGraphile exposes `legislatorByMemberA` /
+  `legislatorByMemberB` — party + name come back inline in one query instead of a
+  separate lookup. Helps every consumer of the table, not just this question.
+- **Passthrough robustness.** `execute_graphql` returns whatever the query
+  returns and #36 left no page-size cap, so a large connection can overflow the
+  agent's context (observed: a full pairwise fetch had to be spilled to a file).
+  Add a docstring rule to use `orderBy` + a small `first:` for "top-N" questions,
+  and optionally a soft response-size guard that truncates + warns. Small
+  standalone MCP patch (behavior change → not folded into the docs-only v0.1.1).
+
+Each subsequent version is independently shippable and adds tools that fall
+into one of three categories:
 
 - **v0.2 — Discovery/lookup tools** (e.g. `find_legislator`, `find_bill`,
   `find_vote`, `list_committees`): the tools an agent reaches for when it
@@ -79,13 +108,13 @@ shippable and adds tools that fall into one of three categories:
   `get_vote_with_positions`, `get_bill`, `get_committee`): "give me
   everything about this entity" — saves round-trips across joined tables.
 - **v0.4 — Aggregation/analysis tools** (e.g. `get_voting_record`,
-  `compare_voters`, `find_party_defectors`): tools that answer questions,
-  not just retrieve data.
-
-The voting-similarity matrix is deliberately *not* on the v0.4 list because
-it needs server-side Postgres aggregation to avoid O(n²) hammering of the
-GraphQL API — that's a DB migration with its own scope and risk profile,
-and it can ship later under a separate plan.
+  `compare_voters`, `find_party_defectors`, and a cross-party
+  `most_agreeing_pairs`): tools that answer questions, not just retrieve data.
+  The pairwise aggregate these need is now deployed (`vote_similarity`), so they
+  no longer require new server-side aggregation — a curated tool does the party
+  lookup, the cross-party filter, the ordering and a top-N cap internally,
+  returning a small already-answered result instead of leaving the agent to
+  improvise (the failure mode the FK above + this tool together resolve).
 
 Past v0.4, the project's wishlist shifts back to improving GovQL itself
 (populating the bills/cosponsors/committees tables, a NL-query helper in

--- a/mcp-server/pyproject.toml
+++ b/mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "govql-mcp-server"
-version = "0.1.0"
+version = "0.1.1"
 description = "MCP server for GovQL — query US Congressional data via GraphQL from any MCP client."
 readme = "README.md"
 license = "MIT"

--- a/mcp-server/src/govql_mcp_server/tools/list_types.py
+++ b/mcp-server/src/govql_mcp_server/tools/list_types.py
@@ -46,7 +46,10 @@ async def list_types(
     Tip: most agents start with `list_types(kind="OBJECT")` to see just the
     queryable entities (Vote, Legislator, Bill, Committee, …), then call
     `describe_type("Query")` to see the available top-level query fields
-    (such as `allVotes`, `allLegislators`, `voteByVoteId`).
+    (such as `allVotes`, `allLegislators`, `voteByVoteId`). The OBJECT list
+    also includes GovQL's **derived analytics views** (e.g. `VoteSimilarity`,
+    `MemberPartyAgreement`) — precomputed answers to common cross-cutting
+    questions, worth preferring over aggregating raw positions yourself.
 
     Returns `{"data": {"types": [{"kind": ..., "name": ..., "description": ...}, ...]}}`
     on success, or `{"data": null, "errors": [...]}` on network failure.

--- a/mcp-server/src/govql_mcp_server/tools/passthrough.py
+++ b/mcp-server/src/govql_mcp_server/tools/passthrough.py
@@ -31,6 +31,16 @@ async def execute_graphql(
     Tables for bills, cosponsors, committees, and committee memberships exist
     in the schema but are not yet populated.
 
+    Beyond the raw tables, GovQL precomputes the expensive cross-cutting
+    analytics as **derived views** — prefer these over pulling `VotePosition`
+    rows and aggregating yourself. The flagship two are `VoteSimilarity`
+    (pairwise agreement between two members in a congress — how often they cast
+    the same Yea/Nay) and `MemberPartyAgreement` (how often a member voted with
+    each party), alongside per-vote and per-member tally views. Before
+    hand-rolling any multi-row computation, call `list_types()` to see the full
+    set (each carries a description) and pick the view that already answers the
+    question.
+
     Common values to know (saves you a wrong-guess round-trip):
 
     - `Vote.category` is a lowercase string. Frequent values: `"nomination"`,

--- a/mcp-server/uv.lock
+++ b/mcp-server/uv.lock
@@ -440,7 +440,7 @@ server = [
 
 [[package]]
 name = "govql-mcp-server"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

Closes #51.

When asked analytical questions (e.g. "which two members of the current Congress vote together most often?"), agents were brute-forcing over raw `Vote`/`VotePosition` rows instead of using the aggregate views, because `execute_graphql` described the raw model — even enumerating the *empty* tables — but never mentioned that the derived analytics views exist. This is a docs-only patch that closes that discoverability gap; no change to the tools' coverage.

### Changes

- **`execute_graphql`** docstring now points agents at the derived views — anchoring on `VoteSimilarity` and `MemberPartyAgreement`, noting the per-vote / per-member tally views, and telling agents to `list_types()` before hand-rolling any multi-row computation.
- **`list_types`** tip calls out that the OBJECT list includes those views.
- Version bump `0.1.0 → 0.1.1`, CHANGELOG entry, README (Status + an aggregate example).
- **`docs/design.md`** roadmap: records v0.1.1 and adds a "Next up" section (see Follow-ups).

### Follow-ups

Testing showed the fix works but `vote_similarity` is still *party-blind* (no FK to `legislators`), so cross-party questions remain awkward. I also noted the tool output for querying `VoteSimilarity` overflows the context limit. Roadmap notes added:
1. add `member_a`/`member_b` → `legislators` FKs (listed as the next task)
2. an `execute_graphql` response-size guard (should be aware of and have some standard solution to this at least)
3. a v0.4 curated `most_agreeing_pairs` tool

## Release checklist

- [ ] merge commit tagged `govql-mcp-server v0.1.1`
- [ ] patch published to PyPI